### PR TITLE
Use a cached object for syncErrors and syncWarnings

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -998,8 +998,8 @@ const createReduxForm = (structure: Structure<*, *>) => {
 
           const pristine = shouldResetValues || deepEqual(initial, values)
           const asyncErrors = getIn(formState, 'asyncErrors')
-          const syncErrors = getIn(formState, 'syncErrors') || {}
-          const syncWarnings = getIn(formState, 'syncWarnings') || {}
+          const syncErrors = getIn(formState, 'syncErrors') || plain.empty
+          const syncWarnings = getIn(formState, 'syncWarnings') || plain.empty
           const registeredFields = getIn(formState, 'registeredFields')
           const valid = isValid(form, getFormState, false)(state)
           const validExceptSubmit = isValid(form, getFormState, true)(state)


### PR DESCRIPTION
It appears that https://github.com/erikras/redux-form/pull/3201 introduced a regression where a prop that was cached to the same value when falling back (https://github.com/erikras/redux-form/pull/3072) now creates a new object each render. This can cause a rendering performance penalty hit due to preventing shallow prop comparisons.

This PR fixes the regression by always using the `empty` property from the plain structure, rather than from the structure being passed as an argument to `createReduxForm` (which I believe was the intended fix in #3201).