### PR TITLE
Re-throw errors if onSubmitFail is not provided

### DIFF
--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -51,12 +51,10 @@ const handleSubmit = (
         setSubmitFailed(...fields)
         if (onSubmitFail) {
           onSubmitFail(error, dispatch, submitError, props)
-        }
-        if (error || onSubmitFail) {
           // if you've provided an onSubmitFail callback, don't re-throw the error
-          return error
+          return error || submitError
         } else {
-          throw submitError
+          throw error || submitError
         }
       }
       if (isPromise(result)) {
@@ -78,12 +76,10 @@ const handleSubmit = (
             setSubmitFailed(...fields)
             if (onSubmitFail) {
               onSubmitFail(error, dispatch, submitError, props)
-            }
-            if (error || onSubmitFail) {
               // if you've provided an onSubmitFail callback, don't re-throw the error
-              return error
+              return error || submitError
             } else {
-              throw submitError
+              throw error || submitError
             }
           }
         )


### PR DESCRIPTION
handleSubmit always returns/resolves with an error instead of re-throwing it. This seems to be a mistake, going by the comment above. Instead, return an appropriate error if there is an onSubmitFail callback and re-throw it otherwise.

This is probably a breaking change, as it can cause exceptions to be thrown on submission errors where they were not previously.