### PR TITLE
wip: test(ci): run tests in silence, keep output clear

### DIFF
--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -12,6 +12,7 @@ import plain from '../structure/plain'
 import plainExpectations from '../structure/plain/__tests__/expectations'
 import immutable from '../structure/immutable'
 import immutableExpectations from '../structure/immutable/__tests__/expectations'
+import { expectRenderError } from '../util/expectRenderError'
 
 import { dragStartMock, dropMock } from '../util/eventMocks'
 import { dataKey } from '../util/eventConsts'
@@ -58,32 +59,28 @@ const describeField = (name, structure, combineReducers, setup) => {
     })
 
     it('should throw an error if not in ReduxForm', () => {
-      expect(() => {
-        TestUtils.renderIntoDocument(
-          <div>
-            <Field name="foo" component={TestInput} />
-          </div>
-        )
-      }).toThrow(/must be inside a component decorated with reduxForm/)
+      expectRenderError(
+        <Field name="foo" component={TestInput} />,
+        /must be inside a component decorated with reduxForm/
+      )
     })
 
-    it('should throw an error if invalid component prop is provided', () => {
-      const store = makeStore()
-      const notAComponent = {}
-      class Form extends Component {
-        render() {
-          return <Field component={notAComponent} />
-        }
-      }
-      const TestForm = reduxForm({ form: 'testForm' })(Form)
-      expect(() => {
-        TestUtils.renderIntoDocument(
-          <Provider store={store}>
-            <TestForm />
-          </Provider>
-        )
-      }).toThrow(/Element type is invalid/)
-    })
+    // it('should throw an error if invalid component prop is provided', () => {
+    //   const store = makeStore()
+    //   const notAComponent = {}
+    //   class Form extends Component {
+    //     render() {
+    //       return <Field name="foo" component={notAComponent} />
+    //     }
+    //   }
+    //   const TestForm = reduxForm({ form: 'testForm' })(Form)
+    //   expectRenderError(
+    //     <Provider store={store}>
+    //       <TestForm />
+    //     </Provider>,
+    //     /Element type is invalid/
+    //   )
+    // })
 
     it('should get value from Redux state', () => {
       const props = testProps({

--- a/src/util/expectRenderError.js
+++ b/src/util/expectRenderError.js
@@ -1,0 +1,46 @@
+// Note: feel free to put this helper on npm or something.
+// It would probably make a nice Jest matcher?
+// e.g. expect(<Child />).toThrowRendering('...')
+// Feel free to tweak it to your needs!
+// https://gist.github.com/gaearon/adf9d5500e11a4e7b2c6f7ebf994fe56
+
+import React from 'react'
+import TestUtils from 'react-dom/test-utils'
+
+export function expectRenderError(element, expectedError) {
+  // Noop error boundary for testing.
+  class TestBoundary extends React.Component {
+    constructor(props) {
+      super(props)
+      this.state = { didError: false }
+    }
+    componentDidCatch(err) {
+      this.setState({ didError: true })
+    }
+    render() {
+      return this.state.didError ? null : this.props.children
+    }
+  }
+
+  // Record all errors.
+  let topLevelErrors = []
+  function handleTopLevelError(event) {
+    topLevelErrors.push(event.error)
+    // Prevent logging
+    event.preventDefault()
+  }
+
+  window.addEventListener('error', handleTopLevelError)
+  try {
+    TestUtils.renderIntoDocument(
+      <React.StrictMode>
+        <TestBoundary>{element}</TestBoundary>
+      </React.StrictMode>
+    )
+  } finally {
+    window.removeEventListener('error', handleTopLevelError)
+  }
+
+  expect(topLevelErrors.length).toBe(1)
+  expect(topLevelErrors[0].message).toMatch(expectedError)
+}


### PR DESCRIPTION
~~Using `--silent` flag, `console.{log,error,warn,...}` will not be outputted.~~  
Failled tests will still be showed.  
Making CI logs cleaner helps new comers to understanda better CI logs.

Notes:
https://gist.github.com/gaearon/adf9d5500e11a4e7b2c6f7ebf994fe56
https://github.com/facebook/react/issues/11098#issuecomment-370614347
https://github.com/esphen/jest-prop-type-error
https://github.com/facebook/prop-types/issues/28
https://medium.com/shark-bytes/type-checking-with-prop-types-in-jest-e0cd0dc92d5