### PR TITLE
Add CodeFund Sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+ <p align="center">
+  <a href="https://codefund.io/properties/21/visit-sponsor">
+    <img src="https://codefund.io/properties/21/sponsor" />
+  </a>
+</p>
+
 [<img src="https://raw.githubusercontent.com/erikras/redux-form/master/logo.png" align="right" class="logo" height="100" width="165"/>](http://erikras.github.io/redux-form/)
 
 # redux-form


### PR DESCRIPTION
CodeFund sponsorships allow companies to sponsor GitHub projects and display their logo at the top of the README. For an example, see https://github.com/standard/standard