### PR TITLE
Fix a broken link in Selectors.md

### DIFF
--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -3,7 +3,7 @@
 [`View source on GitHub`](https://github.com/erikras/redux-form/tree/master/src/selectors)
 
 `redux-form` provides a set of useful Redux state
-[**selectors**](http://redux.js.org/docs/recipes/ComputingDerivedData.html) that may be used in
+[**selectors**](https://redux.js.org/recipes/computing-derived-data/) that may be used in
 any part of your application to query the state of any of your forms.
 
 All of the selectors listed below have the same usage pattern: they all (apart from


### PR DESCRIPTION
http://redux.js.org/docs/recipes/ComputingDerivedData.html is no longer accessible, and I believe that it has been moved to https://redux.js.org/recipes/computing-derived-data/ .