### PR TITLE
fix(field): use onChange return as preventDefault only in RN

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -126,7 +126,12 @@ const createConnectedField = (structure: Structure<*, *>) => {
             name
           )
         } else {
-          defaultPrevented = onChange(event, newValue, previousValue, name)
+          const onChangeResult = onChange(event, newValue, previousValue, name)
+          // Return value of change handler affecting preventDefault is RN
+          // specific behavior.
+          if (isReactNative) {
+            defaultPrevented = onChangeResult
+          }
         }
       }
       if (!defaultPrevented) {


### PR DESCRIPTION
Fixes regression introduced in 8.1.0.

Issue #4309 adds a way to cancel dispatches from RN. However, the method
added also impacts React Web. This leads to a regression in React Web
due to application of RN behavior.

The current change locks the change from #4309 to RN, and maintains
existing behavior otherwise.

Related:
- #4391 outlines a case where this regression may cause problems. While
  the issue mentions RN, this can easily occur outside RN as well.
- #4401 describes a similar issue and a user-end fix.

<!--
Read the [contributing guidelines](https://github.com/redux-form/redux-form/blob/master/CONTRIBUTING.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes #GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/redux-form/redux-form/blob/master/CONTRIBUTING.md
-->

Closes #4391 
Closes #4401 