### PR TITLE
Scripts - Fix postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "lint": "eslint src",
     "precommit": "lint-staged",
     "prepublishOnly": "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build",
-    "postinstall": "node scripts/patch-immutable-flow-error.js && opencollective-postinstall",
+    "postinstall": "opencollective-postinstall",
     "validate": "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build",
     "test": "cross-env NODE_ENV=test jest src --runInBand",
-    "test:flow": "flow check",
+    "test:flow": "node scripts/patch-immutable-flow-error.js && flow check",
     "test:watch": "npm test -- --watch",
     "test:cov": "npm run test -- --coverage"
   },


### PR DESCRIPTION
We're running `node scripts/*` in post-install, but scripts folder is ignored from npm, this generate an error at install.