### PR TITLE
fix: send an event-like object into Field onChange when no event (#4548)

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -72,16 +72,16 @@ const createConnectedField = (structure: Structure<*, *>) => {
       return !!(
         this.props.children ||
         nextProps.children ||
-        (nextPropsKeys.length !== thisPropsKeys.length ||
-          nextPropsKeys.some(prop => {
-            if (~(nextProps.immutableProps || []).indexOf(prop)) {
-              return this.props[prop] !== nextProps[prop]
-            }
-            return (
-              !~propsToNotUpdateFor.indexOf(prop) &&
-              !deepEqual(this.props[prop], nextProps[prop])
-            )
-          }))
+        nextPropsKeys.length !== thisPropsKeys.length ||
+        nextPropsKeys.some(prop => {
+          if (~(nextProps.immutableProps || []).indexOf(prop)) {
+            return this.props[prop] !== nextProps[prop]
+          }
+          return (
+            !~propsToNotUpdateFor.indexOf(prop) &&
+            !deepEqual(this.props[prop], nextProps[prop])
+          )
+        })
       )
     }
 
@@ -93,7 +93,7 @@ const createConnectedField = (structure: Structure<*, *>) => {
       return this.ref.current
     }
 
-    handleChange = (event: any) => {
+    handleChange = (eventOrValue: any) => {
       const {
         name,
         dispatch,
@@ -103,7 +103,7 @@ const createConnectedField = (structure: Structure<*, *>) => {
         _reduxForm,
         value: previousValue
       } = this.props
-      const newValue = onChangeValue(event, { name, parse, normalize })
+      const newValue = onChangeValue(eventOrValue, { name, parse, normalize })
 
       let defaultPrevented = false
       if (onChange) {
@@ -112,13 +112,13 @@ const createConnectedField = (structure: Structure<*, *>) => {
         // to prevent the following error:
         // `One of the sources for assign has an enumerable key on the prototype chain`
         // Reference: https://github.com/facebook/react-native/issues/5507
-        if (!isReactNative && isEvent(event)) {
+        if (!isReactNative) {
           onChange(
             {
-              ...event,
+              ...(isEvent(eventOrValue) ? eventOrValue : (undefined: any)),
               preventDefault: () => {
                 defaultPrevented = true
-                return eventPreventDefault(event)
+                return eventPreventDefault(eventOrValue)
               }
             },
             newValue,
@@ -126,7 +126,12 @@ const createConnectedField = (structure: Structure<*, *>) => {
             name
           )
         } else {
-          const onChangeResult = onChange(event, newValue, previousValue, name)
+          const onChangeResult = onChange(
+            eventOrValue,
+            newValue,
+            previousValue,
+            name
+          )
           // Return value of change handler affecting preventDefault is RN
           // specific behavior.
           if (isReactNative) {


### PR DESCRIPTION
The docs mention that it is possible for an input to call `input.onChange` and pass either an event or a new value as the argument.

They also mention that it's possible to pass `onChange` to a `<Field />` component, and that handler should receive an event as its first argument, with a `preventDefault` method on it which will prevent the change from being dispatched.

It's not explained in the docs that there's any connection between these two APIs. However, since [this change](https://github.com/redux-form/redux-form/pull/4170/files), the consumer only receives an event object in `Field.onChange` if the underlying input has called `input.onChange` with an event.

Since many people (including myself) have been relying on the ability to BOTH pass a value to `input.onChange` and call `event.preventDefault()` within the `Field.onChange` handler, I think we should either make that possible or update the docs to explain the restriction. This PR makes it possible.

Closes #4548
