### PR TITLE
refactor: remove useless `react-lifecycles-compat`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11908,11 +11908,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-redux": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
     "prop-types": "^15.6.1",
-    "react-is": "^16.12.0",
-    "react-lifecycles-compat": "^3.0.4"
+    "react-is": "^16.12.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component } from 'react'
-import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import { withReduxForm } from './ReduxFormContext'
 import type { ReactContext } from './types'
@@ -36,5 +35,4 @@ Form.propTypes = {
   _reduxForm: PropTypes.object
 }
 
-polyfill(Form)
 export default withReduxForm(Form)

--- a/src/createField.js
+++ b/src/createField.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component, createElement } from 'react'
-import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import invariant from 'invariant'
 import createConnectedField from './ConnectedField'
@@ -143,8 +142,6 @@ const createField = (structure: Structure<*, *>) => {
     immutableProps: PropTypes.arrayOf(PropTypes.string),
     _reduxForm: PropTypes.object
   }
-
-  polyfill(Field)
 
   return withReduxForm(Field)
 }

--- a/src/createFieldArray.js
+++ b/src/createFieldArray.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component, createElement } from 'react'
-import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import invariant from 'invariant'
 import createConnectedFieldArray from './ConnectedFieldArray'
@@ -119,7 +118,6 @@ const createFieldArray = (structure: Structure<*, *>) => {
     _reduxForm: PropTypes.object
   }
 
-  polyfill(FieldArray)
   return withReduxForm(FieldArray)
 }
 

--- a/src/createFields.js
+++ b/src/createFields.js
@@ -1,6 +1,5 @@
 // @flow
 import { Component, createElement } from 'react'
-import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import invariant from 'invariant'
 import get from 'lodash/get'
@@ -149,7 +148,6 @@ const createFields = (structure: Structure<*, *>) => {
     ...fieldsPropTypes
   }
 
-  polyfill(Fields)
   return withReduxForm(Fields)
 }
 

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -1,5 +1,4 @@
 // @flow
-import { polyfill } from 'react-lifecycles-compat'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
 import isPromise from 'is-promise'
@@ -1167,7 +1166,6 @@ const createReduxForm = (structure: Structure<*, *>) => {
         }
       }
 
-      polyfill(ReduxForm)
       const WithContext = hoistStatics(
         withReduxForm(ReduxForm),
         WrappedComponent


### PR DESCRIPTION
As of `redux-form@8` major version, minimum `react@16.4` is required
New lifecycles methods were introduced in `react@16.3`
So `react-lifecycles-compat` is not required anymore

https://reactjs.org/blog/2018/03/29/react-v-16-3.html
https://github.com/redux-form/redux-form/releases/tag/v8.0.0
https://github.com/reactjs/react-lifecycles-compat
