### PR TITLE
chore: remove `jest-matcher-utils` in favor of jest `this.utils`

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "immutable": "^3.8.2",
     "insert-line": "^1.1.0",
     "jest": "^24.9.0",
-    "jest-matcher-utils": "^24.9.0",
     "lint-staged": "^8.2.1",
     "lodash-webpack-plugin": "^0.11.5",
     "prettier": "^1.19.1",

--- a/src/structure/immutable/__tests__/expectations.js
+++ b/src/structure/immutable/__tests__/expectations.js
@@ -2,8 +2,6 @@
 import deepEqual from 'deep-equal'
 import { Map, List, Iterable, fromJS } from 'immutable'
 
-import { matcherHint, printReceived, printExpected } from 'jest-matcher-utils'
-
 const deepEqualValues = (a: any, b: any) => {
   if (Iterable.isIterable(a)) {
     return (
@@ -45,12 +43,12 @@ const api = {
     return {
       pass,
       message: () =>
-        matcherHint('.toEqualMap') +
+        this.utils.matcherHint('.toEqualMap') +
         '\n\n' +
         `Expected value to equal map:\n` +
-        `  ${printExpected(fromJS(expected))}\n` +
+        `  ${this.utils.printExpected(fromJS(expected))}\n` +
         `Received:\n` +
-        `  ${printReceived(actual)}`
+        `  ${this.utils.printReceived(actual)}`
     }
   },
 
@@ -59,20 +57,18 @@ const api = {
     const pass =
       actual.length === expected.length &&
       actual.every(actualItem =>
-        expectedItems.some(expectedItem =>
-          deepEqualValues(actualItem, expectedItem)
-        )
+        expectedItems.some(expectedItem => deepEqualValues(actualItem, expectedItem))
       )
 
     return {
       pass,
       message: () =>
-        matcherHint('.toContainExactly') +
+        this.utils.matcherHint('.toContainExactly') +
         '\n\n' +
         `Expected value to contain:\n` +
-        `  ${printExpected(fromJS(expected))}\n` +
+        `  ${this.utils.printExpected(fromJS(expected))}\n` +
         `Received:\n` +
-        `  ${printReceived(actual)}`
+        `  ${this.utils.printReceived(actual)}`
     }
   }
 }

--- a/src/structure/plain/__tests__/expectations.js
+++ b/src/structure/plain/__tests__/expectations.js
@@ -1,6 +1,5 @@
 // @flow
 import { isEqual, isObject } from 'lodash'
-import { matcherHint, printReceived, printExpected } from 'jest-matcher-utils'
 
 const expectations = {
   toBeAMap(actual: any) {
@@ -32,12 +31,12 @@ const expectations = {
     return {
       pass,
       message: () =>
-        matcherHint('.toEqualMap') +
+        this.utils.matcherHint('.toEqualMap') +
         '\n\n' +
         `Expected value to equal:\n` +
-        `  ${printExpected(expected)}\n` +
+        `  ${this.utils.printExpected(expected)}\n` +
         `Received:\n` +
-        `  ${printReceived(actual)}`
+        `  ${this.utils.printReceived(actual)}`
     }
   },
 
@@ -51,12 +50,12 @@ const expectations = {
     return {
       pass,
       message: () =>
-        matcherHint('.toContainExactly') +
+        this.utils.matcherHint('.toContainExactly') +
         '\n\n' +
         `Expected value to contain:\n` +
-        `  ${printExpected(sortedExpected)}\n` +
+        `  ${this.utils.printExpected(sortedExpected)}\n` +
         `Received:\n` +
-        `  ${printReceived(sortedActual)}`
+        `  ${this.utils.printReceived(sortedActual)}`
     }
   }
 }


### PR DESCRIPTION
https://jestjs.io/docs/en/expect#thisutils
