### PR TITLE
fix(v7): improve `SubmissionError` detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2714,8 +2714,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         }
       }
@@ -3439,7 +3439,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -3551,8 +3551,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         },
         "load-json-file": {
@@ -3561,10 +3561,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
           }
         },
         "path-type": {
@@ -3573,7 +3573,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "read-pkg": {
@@ -3582,9 +3582,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
           }
         },
         "read-pkg-up": {
@@ -3593,8 +3593,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
           }
         },
         "strip-bom": {
@@ -7870,8 +7870,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "log-symbols": {
@@ -7880,7 +7880,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         }
       }
@@ -8553,7 +8553,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -10706,7 +10706,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }

--- a/src/SubmissionError.js
+++ b/src/SubmissionError.js
@@ -1,7 +1,12 @@
 // @flow
 import ExtendableError from 'es6-error'
 
+const __FLAG__ = '@@redux-form/submission-error-flag'
+
 class SubmissionError extends ExtendableError {
+  /** @private */
+  static __FLAG__ = __FLAG__
+
   constructor(errors: Object) {
     super('Submit Validation Failed')
     this.errors = errors
@@ -9,3 +14,10 @@ class SubmissionError extends ExtendableError {
 }
 
 export default SubmissionError
+
+export function isSubmissionError(error: any): boolean {
+  return (
+    (error && error.constructor && error.constructor.__FLAG__ === __FLAG__) ===
+    true
+  )
+}

--- a/src/__tests__/SubmissionError.spec.js
+++ b/src/__tests__/SubmissionError.spec.js
@@ -1,0 +1,17 @@
+import ExtendableError from 'es6-error'
+import SubmissionError, { isSubmissionError } from '../SubmissionError'
+
+class FakeSubmissionError {
+  static __FLAG__ = '@@redux-form/submission-error-flag'
+}
+
+describe('isSubmissionError', () => {
+  it('should return `true` only when argument is instance `SubmissionError`', () => {
+    expect(isSubmissionError(new SubmissionError({}))).toBe(true)
+    expect(isSubmissionError(new FakeSubmissionError())).toBe(true)
+    expect(isSubmissionError(new Error())).toBe(false)
+    expect(isSubmissionError(new ExtendableError())).toBe(false)
+    expect(isSubmissionError({})).toBe(false)
+    expect(isSubmissionError()).toBe(false)
+  })
+})

--- a/src/actions.js
+++ b/src/actions.js
@@ -290,7 +290,7 @@ const initialize: Initialize = (
   form: string,
   values: Object,
   keepDirty?: boolean | Object,
-  otherMeta?: Object = {}
+  otherMeta: Object = {}
 ): InitializeAction => {
   if (keepDirty instanceof Object) {
     otherMeta = keepDirty

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -1,6 +1,6 @@
 // @flow
 import isPromise from 'is-promise'
-import SubmissionError from './SubmissionError'
+import SubmissionError, { isSubmissionError } from './SubmissionError'
 import type { Dispatch } from 'redux'
 import type { Props } from './createReduxForm'
 
@@ -38,10 +38,9 @@ const handleSubmit = (
       try {
         result = submit(values, dispatch, props)
       } catch (submitError) {
-        const error =
-          submitError instanceof SubmissionError
-            ? submitError.errors
-            : undefined
+        const error = isSubmissionError(submitError)
+          ? submitError.errors
+          : undefined
         stopSubmit(error)
         setSubmitFailed(...fields)
         if (onSubmitFail) {
@@ -66,10 +65,9 @@ const handleSubmit = (
             return submitResult
           },
           submitError => {
-            const error =
-              submitError instanceof SubmissionError
-                ? submitError.errors
-                : undefined
+            const error = isSubmissionError(submitError)
+              ? submitError.errors
+              : undefined
             stopSubmit(error)
             setSubmitFailed(...fields)
             if (onSubmitFail) {


### PR DESCRIPTION
Now event after obfuscation, or importing SubmissionForm
from a different context, `isSubmissionError` will return true
only for `SubmissionError`

Closes #4092
Closes #4162
