### PR TITLE
Add possibility to change function passed to handleSubmit

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -14,14 +14,16 @@ class Form extends Component<PropsWithContext> {
   constructor(props: PropsWithContext) {
     super(props)
     if (!props._reduxForm) {
-      throw new Error(
-        'Form must be inside a component decorated with reduxForm()'
-      )
+      throw new Error('Form must be inside a component decorated with reduxForm()')
     }
   }
 
   UNSAFE_componentWillMount() {
     this.props._reduxForm.registerInnerOnSubmit(this.props.onSubmit)
+  }
+
+  UNSAFE_componentWillUpdate(nextProps: Props) {
+    this.props._reduxForm.registerInnerOnSubmit(nextProps.onSubmit)
   }
 
   render() {

--- a/src/Form.js
+++ b/src/Form.js
@@ -18,11 +18,11 @@ class Form extends Component<PropsWithContext> {
     }
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this.props._reduxForm.registerInnerOnSubmit(this.props.onSubmit)
   }
 
-  UNSAFE_componentWillUpdate(nextProps: Props) {
+  componentDidUpdate(nextProps: Props) {
     this.props._reduxForm.registerInnerOnSubmit(nextProps.onSubmit)
   }
 

--- a/src/Form.js
+++ b/src/Form.js
@@ -22,8 +22,10 @@ class Form extends Component<PropsWithContext> {
     this.props._reduxForm.registerInnerOnSubmit(this.props.onSubmit)
   }
 
-  componentDidUpdate(nextProps: Props) {
-    this.props._reduxForm.registerInnerOnSubmit(nextProps.onSubmit)
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.onSubmit !== prevProps.onSubmit) {
+      this.props._reduxForm.registerInnerOnSubmit(this.props.onSubmit)
+    }
   }
 
   render() {


### PR DESCRIPTION
Closes #4682

When submiting form remotely by dispatching `submit` action and during `Form` lifetime and method provided to handleSubmit has changed - it isn't fired - only first function provided to `Form` is fired. After invastigation I've noticed that for remote submitting `submit` function from `createReduxForm.js` calls method `innerOnSubmit()` and it is set with following function: `registerInnerOnSubmit: innerOnSubmit => (this.innerOnSubmit = innerOnSubmit)`. 
In `Form.js` I can see that it only register method when component will mount ` this.props._reduxForm.registerInnerOnSubmit(this.props.onSubmit)` so even if you change method provided to handleSubmit during `Form` life, it wont be fired `onSubmit`. 
My fix adds possibility to change that method during `Form` life.