### PR TITLE
Fix peer dependency for react 17.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "webpack-cli": "^3.3.11"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.4.2 || ^17.0.0",
     "react-redux": "^6.0.1 || ^7.0.0",
     "redux": "^3.7.2 || ^4.0.0",
     "immutable": "^3.8.2 || ^4.0.0"


### PR DESCRIPTION
Related tweet 

https://twitter.com/wesbos/status/1359173446740172810

Fixes Could not resolve dependency:
peer react@"^16.4.2" from redux-form@8.3.7

https://github.com/redux-form/redux-form/issues/4721

and 

https://github.com/redux-form/redux-form/issues/4710


