### PR TITLE
Avoid assuming that module exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js -o dist/redux-form.min.js",
     "clean": "rimraf dist lib es",
     "lint": "eslint src",
-    "prepublishOnly": "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build",
+    "prepare": "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build",
     "validate": "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build && size-limit",
     "test": "jest",
     "test:flow": "node scripts/patch-immutable-flow-error.js && flow check",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js -o dist/redux-form.min.js",
     "clean": "rimraf dist lib es",
     "lint": "eslint src",
-    "prepare": "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build",
+    "prepare": "npm run build",
     "validate": "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build && size-limit",
     "test": "jest",
     "test:flow": "node scripts/patch-immutable-flow-error.js && flow check",

--- a/src/util/isHotReloading.js
+++ b/src/util/isHotReloading.js
@@ -1,6 +1,6 @@
 // @flow
 const isHotReloading = (): boolean => {
-  const castModule = (typeof module !== 'undefined' && module) as any
+  const castModule: any = typeof module !== 'undefined' && module
   return !!(
     castModule &&
     castModule.hot &&

--- a/src/util/isHotReloading.js
+++ b/src/util/isHotReloading.js
@@ -1,6 +1,6 @@
 // @flow
 const isHotReloading = (): boolean => {
-  const castModule = (module: any)
+  const castModule = (globalThis.module: any)
   return !!(
     typeof castModule !== 'undefined' &&
     castModule.hot &&

--- a/src/util/isHotReloading.js
+++ b/src/util/isHotReloading.js
@@ -1,8 +1,8 @@
 // @flow
 const isHotReloading = (): boolean => {
-  const castModule = (globalThis.module: any)
+  const castModule = (typeof module !== 'undefined' && module) as any
   return !!(
-    typeof castModule !== 'undefined' &&
+    castModule &&
     castModule.hot &&
     typeof castModule.hot.status === 'function' &&
     castModule.hot.status() === 'apply'


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/redux-form/redux-form/blob/master/CONTRIBUTING.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes #GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/redux-form/redux-form/blob/master/CONTRIBUTING.md
-->

This PR fixes a significant regression in `redux-form` v8.1.0 (and above), where the following error is thrown in the browser on any page using `redux-form`:

```
Uncaught ReferenceError: module is not defined
```

I fixed it by ensuring that the `module` reference is guarded by `typeof`.

Note that I also updated package.json to use an npm `prepare` script instead of `prepublishOnly`, because that allows me to use my GitHub fork as a dependency in my app. I think it would be a good idea to use `prepare`, but I'm happy to revert that commit if you'd prefer, as it's unrelated to the bugfix.