### PR TITLE
Fix initial values bug

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -928,7 +928,7 @@ export default function createReduxForm(structure: Structure<any, any>) {
 
           let initial = initialValues || stateInitial || empty
 
-          if (!shouldUpdateInitialValues) {
+          if (shouldUpdateInitialValues) {
             initial = stateInitial || empty
           }
 


### PR DESCRIPTION
Reverses https://github.com/redux-form/redux-form/pull/4020 which momentarily sets initial values to `{}` and causes an error in many of our validators.
