### PR TITLE
Update lodash to 4.17.21 because of a vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11092,9 +11092,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
       "version": "4.17.15",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "hoist-non-react-statics": "^3.3.2",
     "invariant": "^2.2.4",
     "is-promise": "^2.1.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "prop-types": "^15.6.1",
     "react-is": "^16.4.2"
   },


### PR DESCRIPTION
This resolves the production vulnerability warning from npm audit.

I used node 12 for this fix to not change the version of the package.json. 

Closes #4785
