### PR TITLE
Remove usages of `Component.defaultProps` because support for this will be removed from memo components in the future

### DIFF
--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -30,7 +30,9 @@ export default function createConnectedFieldArray(structure: Structure<any, any>
   }
 
   class ConnectedFieldArray extends Component<Props> {
-    static defaultProps: DefaultProps
+    static defaultProps: DefaultProps = {
+      rerenderOnEveryChange: false
+    }
     ref: ElementRef<any> = React.createRef()
 
     shouldComponentUpdate(nextProps: Props) {
@@ -122,10 +124,6 @@ export default function createConnectedFieldArray(structure: Structure<any, any>
     component: validateComponentProp,
     props: PropTypes.object,
     rerenderOnEveryChange: PropTypes.bool
-  }
-
-  ConnectedFieldArray.defaultProps = {
-    rerenderOnEveryChange: false
   }
 
   const connector = connect(

--- a/src/FormSection.js
+++ b/src/FormSection.js
@@ -19,15 +19,15 @@ export type DefaultProps = {
 }
 
 class FormSection extends Component<PropsWithContext> {
-  static defaultProps: DefaultProps
+  static defaultProps: DefaultProps = {
+    component: 'div'
+  }
   context: ReactContext
 
   constructor(props: PropsWithContext) {
     super(props)
     if (!props._reduxForm) {
-      throw new Error(
-        'FormSection must be inside a component decorated with reduxForm()'
-      )
+      throw new Error('FormSection must be inside a component decorated with reduxForm()')
     }
   }
 
@@ -66,10 +66,6 @@ class FormSection extends Component<PropsWithContext> {
 FormSection.propTypes = {
   name: PropTypes.string.isRequired,
   component: validateComponentProp
-}
-
-FormSection.defaultProps = {
-  component: 'div'
 }
 
 export default withReduxForm(FormSection)

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -29,6 +29,7 @@ import type { Params as ShouldAsyncValidateParams } from './defaultShouldAsyncVa
 import type { Params as ShouldValidateParams } from './defaultShouldValidate'
 import type { Params as ShouldErrorParams } from './defaultShouldError'
 import type { Params as ShouldWarnParams } from './defaultShouldWarn'
+import { withDefaultProps } from './util/withDefaultProps'
 
 const isClassComponent = (Component: ?any) =>
   Boolean(
@@ -1027,8 +1028,9 @@ export default function createReduxForm(structure: Structure<any, any>) {
         undefined,
         { forwardRef: true }
       )
-      const ConnectedForm = hoistStatics<any, any, any, any>(connector(Form), WrappedComponent)
-      ConnectedForm.defaultProps = config
+      const ConnectedForm = withDefaultProps(
+        hoistStatics<any, any, any, any>(connector(Form), WrappedComponent)
+      )(config)
 
       // build outer component to expose instance api
       class ReduxForm extends React.Component<Props> {
@@ -1085,12 +1087,9 @@ export default function createReduxForm(structure: Structure<any, any>) {
         }
       }
 
-      const WithContext = hoistStatics<any, any, any, any>(
-        withReduxForm(ReduxForm),
-        WrappedComponent
-      )
-      WithContext.defaultProps = config
-      return WithContext
+      return withDefaultProps(
+        hoistStatics<any, any, any, any>(withReduxForm(ReduxForm), WrappedComponent)
+      )(config)
     }
   }
 }

--- a/src/util/withDefaultProps.js
+++ b/src/util/withDefaultProps.js
@@ -1,0 +1,4 @@
+import React, { forwardRef } from 'react'
+
+export const withDefaultProps = Component => defaultProps =>
+  forwardRef((props, ref) => <Component {...defaultProps} {...props} ref={ref} />)


### PR DESCRIPTION
We were noticing these errors in the console

```
Support for defaultProps will be removed from memo components in a future major release. Use JavaScript default parameters instead.
```

It wasn't possible to pass default props directly to `static defaultProps` in every instance. As a work around I added the `withDefaultProps` higher-order-component. All the tests pass as before.
